### PR TITLE
shared thread pools, closes #5

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,4 +5,5 @@
 - [ ] delay reading the source file until the very point where we need it; pitch
 - [ ] replay loader RPCs for items cached by loaders like `tslint-loader` where the output is actually RPCs like `this.emitWarning` and `this.emitError`
 - [ ] better coverage for background loader failures
-- [ ] 
+- [ ] caching test
+- [ ] experiment with not serializing worker output to file and instead shoving things down the process stream (ie `compiledPath` shizzle)

--- a/lib/HappyFakeCompiler.js
+++ b/lib/HappyFakeCompiler.js
@@ -1,17 +1,22 @@
 var assert = require('assert');
 
-function HappyFakeCompiler(id, sendMessageImpl, options) {
-  assert(options && typeof options === 'object',
-    "Expected worker options to contain @compiledOptions.");
+function HappyFakeCompiler(id, sendMessageImpl) {
+  assert(typeof sendMessageImpl === 'function');
 
   this._id = id;
   this._sendMessageImpl = sendMessageImpl;
   this._requests = {};
   this._messageId = 0;
-  this.options = options;
+  this.options = {};
 }
 
 var HFCPt = HappyFakeCompiler.prototype;
+
+HFCPt.configure = function(compilerOptions) {
+  assert(compilerOptions && typeof compilerOptions === 'object');
+
+  this.options = compilerOptions;
+};
 
 /**
  * @public

--- a/lib/HappyMessage.js
+++ b/lib/HappyMessage.js
@@ -1,45 +1,70 @@
+// READY
+//
+// Emitted when a channel is open and ready to accept further messages.
+//
+//     shape({});
+
+// CONFIGURE
+//
+// Emitted by each HappyThread to its channel with the current compiler's
+// options so that the workers may use those options in their FakeCompiler /
+// FakeLoaderContext.
+//
+//     shape({
+//       data: shape({
+//         compilerOptions: string
+//       })
+//     });
+
+// CONFIGURE_DONE
+//
+// Emitted when a channel has successfully deserialized and configured its
+// workers with the compiler options.
+//
+//     shape({});
+
 // COMPILE
 //
-// shape({
-//   sourcePath: string,
-//   compiledPath: string,
-//   loaderContext: object,
-// });
+//     shape({
+//       sourcePath: string,
+//       compiledPath: string,
+//       loaderContext: object,
+//     });
 
 // COMPILE_DONE
 //
-// shape({
-//   sourcePath: string,
-//   compiledPath: string,
-//   success: bool,
-// });
+//     shape({
+//       sourcePath: string,
+//       compiledPath: string,
+//       success: bool,
+//     });
 
 // COMPILER_REQUEST
 //
-// shape({
-//   data: shape({
-//     id: string.isRequired,
-//     type: oneOf([ 'resolve' ]).isRequired,
+//     shape({
+//       data: shape({
+//         id: string.isRequired,
+//         type: oneOf([ 'resolve' ]).isRequired,
 //
-//     payload: oneOfType([
-//       // resolve
-//       shape({
-//         context: string,
-//         resource: string,
+//         payload: oneOfType([
+//           // resolve
+//           shape({
+//             context: string,
+//             resource: string,
+//           }),
+//         ]).isRequired,
 //       }),
-//     ]).isRequired,
-//   }),
-// });
+//     });
 
 // COMPILER_RESPONSE
 //
-// shape({
-//   data: shape({
-//     id: string.isRequired,
+//     shape({
+//       data: shape({
+//         id: string.isRequired,
 //
-//     payload: shape({
-//       error: string,
-//       result: object,
-//     })
-//   })
-// });
+//         payload: shape({
+//           error: string,
+//           result: object,
+//         })
+//       })
+//     });

--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -9,8 +9,8 @@ var HappyUtils = require('./HappyUtils');
 var HappyWorker = require('./HappyWorker');
 var HappyFakeCompiler = require('./HappyFakeCompiler');
 var WebpackUtils = require('./WebpackUtils');
-var JSONSerializer = require('./JSONSerializer');
 var OptionParser = require('./OptionParser');
+var JSONSerializer = require('./JSONSerializer');
 var fnOnce = require('./fnOnce');
 var pkg = require('../package.json');
 var uid = 0;
@@ -24,6 +24,8 @@ function HappyPlugin(userConfig) {
   this.name = 'HappyPack';
   this.state = {
     started: false,
+    loaders: [],
+    baseLoaderRequest: '',
     foregroundWorker: null,
   };
 
@@ -31,6 +33,7 @@ function HappyPlugin(userConfig) {
     id:                 { type: 'string' },
     tempDir:            { type: 'string', default: '.happypack' },
     threads:            { type: 'number', default: 3 },
+    threadPool:         { type: 'object', default: null },
     cache:              { type: 'boolean', default: true },
     cacheContext:       { default: {} },
     cachePath:          { type: 'string' },
@@ -53,12 +56,10 @@ function HappyPlugin(userConfig) {
     }
   }, "HappyPack[" + this.id + "]");
 
-  if (isNaN(this.config.threads)) {
-    throw new Error("ArgumentError: Happy[" + this.config.id + "] threads option is invalid.");
-  }
+  this.threadPool = this.config.threadPool || HappyThreadPool({
+    size: this.config.threads
+  });
 
-  this.config.threads = Math.max(Math.ceil(parseInt(this.config.threads, 10)), 1);
-  this.config.optionsPath = path.resolve(this.config.tempDir, 'options--' + this.id + '.json');
   this.cache = HappyFSCache(this.id, this.config.cachePath ?
     path.resolve(this.config.cachePath) :
     path.resolve(this.config.tempDir, 'cache--' + this.id + '.json')
@@ -80,7 +81,7 @@ HappyPlugin.prototype.apply = function(compiler) {
     // Once the initial build has completed, we create a foreground worker and
     // perform all compilations in this thread instead:
     compiler.plugin('done', function() {
-      that.state.foregroundWorker = createForegroundWorker(compiler, that.config.loaders);
+      that.state.foregroundWorker = createForegroundWorker(compiler, that.state.loaders);
     });
 
     // TODO: anything special to do here?
@@ -115,8 +116,12 @@ HappyPlugin.prototype.start = function(compiler, done) {
 
   assert(!that.state.started, "HappyPlugin has already been started!");
 
-  console.log('Happy[%s]: Version: %s. Using cache? %s. Threads: %d',
-    that.id, pkg.version, that.config.cache ? 'yes' : 'no', that.config.threads);
+  console.log('Happy[%s]: Version: %s. Using cache? %s. Threads: %d%s',
+    that.id, pkg.version,
+    that.config.cache ? 'yes' : 'no',
+    that.threadPool.size,
+    that.config.threadPool ? ' (shared pool)' : ''
+  );
 
   async.series([
     function registerCompilerForRPCs(callback) {
@@ -126,20 +131,18 @@ HappyPlugin.prototype.start = function(compiler, done) {
     },
 
     function normalizeLoaders(callback) {
-      var loaders = that.config.loaders
+      that.state.loaders = that.config.loaders
         .map(WebpackUtils.disectLoaderString)
         .reduce(function(allLoaders, loadersFoundInString) {
           return allLoaders.concat(loadersFoundInString);
         }, [])
       ;
 
-      that.config.loaders = loaders;
-
-      callback();
+      callback(null);
     },
 
     function resolveLoaders(callback) {
-      var loaderPaths = that.config.loaders.map(function(loader) {
+      var loaderPaths = that.state.loaders.map(function(loader) {
         if (loader.query) {
           return loader.path + loader.query;
         }
@@ -149,8 +152,8 @@ HappyPlugin.prototype.start = function(compiler, done) {
       WebpackUtils.resolveLoaders(compiler, loaderPaths, function(err, loaders) {
         if (err) return callback(err);
 
-        that.config.loaders = loaders;
-        that.baseLoaderRequest = that.config.loaders.map(function(loader) {
+        that.state.loaders = loaders;
+        that.state.baseLoaderRequest = loaders.map(function(loader) {
           return loader.path + (loader.query || '');
         }).join('!');
 
@@ -161,7 +164,7 @@ HappyPlugin.prototype.start = function(compiler, done) {
     function loadCache(callback) {
       if (that.config.cache) {
         that.cache.load({
-          loaders: that.config.loaders,
+          loaders: that.state.loaders,
           external: that.config.cacheContext
         });
       }
@@ -169,28 +172,23 @@ HappyPlugin.prototype.start = function(compiler, done) {
       callback();
     },
 
-    function serializeOptions(callback) {
-      // serialize the options so that the workers can pick them up
-      try {
+    function launchAndConfigureThreads(callback) {
+      that.threadPool.start(function() {
+        var serializedOptions;
+        var compilerOptions = HappyPlugin.extractCompilerOptions(compiler.options);
 
-        fs.writeFileSync(that.config.optionsPath, JSONSerializer.serialize({
-          loaders: that.config.loaders,
-          compilerOptions: HappyPlugin.extractCompilerOptions(compiler.options)
-        }), 'utf-8');
+        try {
+          serializedOptions = JSONSerializer.serialize(compilerOptions);
+        }
+        catch(e) {
+          console.error('Happy[%s]: Unable to serialize options!!! This is an internal error.', that.id);
+          console.error(compilerOptions);
 
-        callback();
-      }
-      catch(e) {
-        console.error('Happy[%s]: Unable to serialize options!!! This is an internal error.', that.id);
-        console.error(compiler.options || compiler);
+          return callback(e);
+        }
 
-        callback(e);
-      }
-    },
-
-    function launchThreads(callback) {
-      that.threadPool = HappyThreadPool(that.config);
-      that.threadPool.start(callback);
+        that.threadPool.configure(serializedOptions, callback);
+      });
     },
 
     function markStarted(callback) {
@@ -210,10 +208,7 @@ HappyPlugin.prototype.stop = function() {
     this.cache.save();
   }
 
-  if (this.threadPool) {
-    this.threadPool.stop();
-    this.threadPool = null;
-  }
+  this.threadPool.stop();
 };
 
 HappyPlugin.prototype.compile = function(loaderContext, done) {
@@ -253,6 +248,7 @@ HappyPlugin.prototype._performCompilationRequest = function(worker, loaderContex
   cache.invalidateEntryFor(filePath);
 
   worker.compile({
+    loaders: this.state.loaders,
     compiledPath: path.resolve(this.config.tempDir, HappyUtils.generateCompiledPath(filePath)),
     loaderContext: loaderContext,
   }, function(result) {
@@ -270,7 +266,7 @@ HappyPlugin.prototype._performCompilationRequest = function(worker, loaderContex
 };
 
 HappyPlugin.prototype.generateRequest = function(resource) {
-  return this.baseLoaderRequest + '!' + resource;
+  return this.state.baseLoaderRequest + '!' + resource;
 };
 
 // export this so that users get to override if needed
@@ -326,5 +322,8 @@ function createForegroundWorker(compiler, loaders) {
 
   return new HappyWorker({ compiler: fakeCompiler, loaders: loaders });
 }
+
+// convenience accessor to relieve people from requiring the file directly:
+HappyPlugin.ThreadPool = HappyThreadPool;
 
 module.exports = HappyPlugin;

--- a/lib/HappyTestUtils.js
+++ b/lib/HappyTestUtils.js
@@ -145,16 +145,21 @@ exports.spyOnActiveLoader = function(fn) {
 };
 
 exports.assertNoWebpackErrors = function(err, rawStats, done) {
-  if (err) return done(err);
+  if (err) {
+    done(err);
+    return true;
+  }
 
   var stats = rawStats.toJson();
 
   if (stats.errors.length) {
-    return done(stats.errors);
+    done(stats.errors);
+    return true;
   }
 
   if (stats.warnings.length) {
-    return done(stats.warnings);
+    done(stats.warnings);
+    return true;
   }
 };
 

--- a/lib/HappyThread.js
+++ b/lib/HappyThread.js
@@ -6,7 +6,7 @@ var HappyRPCHandler = require('./HappyRPCHandler');
 var Once = require('./fnOnce');
 var WORKER_BIN = path.resolve(__dirname, 'HappyWorkerChannel.js');
 
-function HappyThread(threadId, config) {
+function HappyThread(id) {
   var fd;
   var callbacks = {};
 
@@ -14,7 +14,7 @@ function HappyThread(threadId, config) {
     open: function(onReady) {
       var emitReady = Once(onReady);
 
-      fd = fork(WORKER_BIN, [threadId, config.optionsPath]);
+      fd = fork(WORKER_BIN, [id]);
 
       fd.on('error', throwError);
       fd.on('exit', function(exitCode) {
@@ -25,14 +25,14 @@ function HappyThread(threadId, config) {
 
       fd.on('message', function acceptMessageFromWorker(message) {
         if (message.name === 'READY') {
-          HappyLogger.info('Happy thread[%d] is now open.', threadId);
+          HappyLogger.info('Happy thread[%d] is now open.', id);
 
           emitReady();
         }
         else if (message.name === 'COMPILED') {
           var filePath = message.sourcePath;
 
-          HappyLogger.info('Thread[%d]: a file has been compiled.', threadId, filePath);
+          HappyLogger.info('Thread[%d]: a file has been compiled.', id, filePath);
 
           assert(typeof callbacks[filePath] === 'function',
             "HappyThread: expected loader to be pending on source file '" +
@@ -60,6 +60,21 @@ function HappyThread(threadId, config) {
               }
             });
           });
+        }
+      });
+    },
+
+    configure: function(compilerOptions, done) {
+      fd.once('message', function(message) {
+        if (message.name === 'CONFIGURE_DONE') {
+          done();
+        }
+      });
+
+      fd.send({
+        name: 'CONFIGURE',
+        data: {
+          compilerOptions: compilerOptions
         }
       });
     },
@@ -93,7 +108,7 @@ function HappyThread(threadId, config) {
       fd.kill('SIGINT');
       fd = null;
 
-      HappyLogger.info('Happy thread[%d] is now closed.', threadId);
+      HappyLogger.info('Happy thread[%d] is now closed.', id);
     },
   };
 }

--- a/lib/HappyThreadPool.js
+++ b/lib/HappyThreadPool.js
@@ -1,12 +1,44 @@
 var async = require('async');
+var assert = require('assert');
 var HappyThread = require('./HappyThread');
 
+/**
+ *
+ * @param {Object} config
+ * @param {Number} config.threads
+ * @param {String} config.optionsPath
+ *
+ * @return {[type]}        [description]
+ */
 module.exports = function HappyThreadPool(config) {
-  var threads = createThreads(config.threads, config);
+  assert(!isNaN(config.size),
+    "ArgumentError: HappyThreadPool requires a valid integer for its size, but got NaN."
+  );
+
+  assert(config.size > 0,
+    "ArgumentError: HappyThreadPool requires a positive integer for its size " +
+    ", but got {" + config.size + "}."
+  );
+
+  var threads = createThreads(config.size, config);
 
   return {
-    start: function(onStart) {
-      async.parallel(threads.filter(not(send('isOpen'))).map(get('open')), onStart);
+    size: config.size,
+
+    start: function(done) {
+      async.parallel(threads.filter(not(send('isOpen'))).map(get('open')), done);
+    },
+
+    configure: function(compilerOptions, done) {
+      assert(!threads.some(not(send('isOpen'))),
+        "ThreadPool must be started before attempting to configure it!"
+      );
+
+      async.parallel(threads.map(function(thread) {
+        return function(callback) {
+          thread.configure(compilerOptions, callback);
+        }
+      }), done);
     },
 
     isRunning: function() {

--- a/lib/HappyWorker.js
+++ b/lib/HappyWorker.js
@@ -4,20 +4,28 @@ var applyLoaders = require('./applyLoaders');
 var serializeError = require('./serializeError');
 
 function HappyWorker(params) {
-  assert(Array.isArray(params.loaders),
-    "Expected worker options to contain a @loaders array.");
-
-  this._loaders = params.loaders;
   this._compiler = params.compiler;
 }
 
+/**
+ * @param  {Object} params
+ * @param  {Object} params.loaderContext
+ * @param  {String} params.loaderContext.resourcePath
+ * @param  {String} params.compiledPath
+ * @param  {Array.<String>} params.loaders
+ * @param  {Function} done
+ */
 HappyWorker.prototype.compile = function(params, done) {
   assert(typeof params.loaderContext.resourcePath === 'string',
-    "Bad message; expected @sourcePath to contain path to the source file!"
+    "ArgumentError: expected params.sourcePath to contain path to the source file."
   );
 
   assert(typeof params.compiledPath === 'string',
-    "Bad message; expected @compiledPath to contain path to the compiled file!"
+    "ArgumentError: expected params.compiledPath to contain path to the compiled file."
+  );
+
+  assert(Array.isArray(params.loaders),
+    "ArgumentError: expected params.loaders to contain a list of loaders."
   );
 
   var sourcePath = params.loaderContext.resourcePath;
@@ -27,7 +35,7 @@ HappyWorker.prototype.compile = function(params, done) {
 
   applyLoaders({
     compiler: this._compiler,
-    loaders: this._loaders,
+    loaders: params.loaders,
     loaderContext: params.loaderContext,
   }, source, null, function(err, code/*, map*/) {
     if (err) {

--- a/lib/HappyWorkerChannel.js
+++ b/lib/HappyWorkerChannel.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
 var JSONSerializer = require('./JSONSerializer');
 var HappyFakeCompiler = require('./HappyFakeCompiler');
 var HappyWorker = require('./HappyWorker');
@@ -10,28 +9,18 @@ if (process.argv[1] === __filename) {
 }
 
 function startAsWorker() {
-  var id = String(process.argv[2]);
-  var optionsFilePath = process.argv[3];
-  var options = JSONSerializer.deserialize(fs.readFileSync(optionsFilePath, 'utf-8'));
-
-  start(id, process, options);
+  HappyWorkerChannel(String(process.argv[2]), process);
 }
 
-function start(id, stream, options) {
-  var fakeCompiler = new HappyFakeCompiler(id, stream.send.bind(stream), options.compilerOptions);
-  var worker = new HappyWorker({
-    loaders: options.loaders,
-    compiler: fakeCompiler
-  });
+function HappyWorkerChannel(id, stream) {
+  var fakeCompiler = new HappyFakeCompiler(id, stream.send.bind(stream));
+  var worker = new HappyWorker({ compiler: fakeCompiler });
 
   stream.on('message', accept);
   stream.send({ name: 'READY' });
 
   function accept(message) {
-    if (message.name === 'COMPILER_RESPONSE') {
-      fakeCompiler._handleResponse(message.data);
-    }
-    else if (message.name === 'COMPILE') {
+    if (message.name === 'COMPILE') {
       worker.compile(message.data, function(result) {
         stream.send({
           name: 'COMPILED',
@@ -41,10 +30,20 @@ function start(id, stream, options) {
         });
       });
     }
+    else if (message.name === 'COMPILER_RESPONSE') {
+      fakeCompiler._handleResponse(message.data);
+    }
+    else if (message.name === 'CONFIGURE') {
+      fakeCompiler.configure(JSONSerializer.deserialize(message.data.compilerOptions));
+
+      stream.send({
+        name: 'CONFIGURE_DONE'
+      });
+    }
     else {
       console.warn('ignoring unknown message:', message);
     }
   }
 }
 
-module.exports = start;
+module.exports = HappyWorkerChannel;

--- a/lib/__tests__/HappyPlugin.integration.test.js
+++ b/lib/__tests__/HappyPlugin.integration.test.js
@@ -178,6 +178,50 @@ describe('[Integration] HappyPlugin', function() {
     });
   });
 
+  it("passes compiler options down to the background loaders", function(done) {
+    const outputDir = tempDir('integration-[guid]');
+    const loader = createLoader(function() {
+      return `// ${this.options.output.path}`;
+    });
+
+    const compiler = webpack({
+      entry: {
+        main: fixturePath('integration/index.js')
+      },
+
+      output: {
+        filename: '[name].js',
+        path: outputDir
+      },
+
+      module: {
+        loaders: [{
+          test: /.js$/,
+          loader: TestUtils.HAPPY_LOADER_PATH
+        }]
+      },
+
+      plugins: [
+        new HappyPlugin({
+          loaders: [ loader.path ],
+        })
+      ]
+    });
+
+    compiler.run(function(err, rawStats) {
+      if (TestUtils.assertNoWebpackErrors(err, rawStats, done)) {
+        return;
+      }
+
+      assert.match(
+        fs.readFileSync(path.join(outputDir, 'main.js'), 'utf-8'),
+        `// ${outputDir}`
+      );
+
+      done();
+    });
+  });
+
   // TODO pitch loader support
   it.skip('works with multiple plugins', function(done) {
     const outputDir = tempDir('integration-[guid]');

--- a/lib/__tests__/HappyPlugin.test.js
+++ b/lib/__tests__/HappyPlugin.test.js
@@ -40,9 +40,9 @@ describe('HappyPlugin', function() {
       const inputFile = createFile('a.js', 'hello!');
 
       subject.state.compiler = { options: {} };
+      subject.state.loaders = subject.config.loaders;
       subject.state.foregroundWorker = new HappyWorker({
-        compiler: subject.state.compiler,
-        loaders: subject.config.loaders
+        compiler: subject.state.compiler
       });
 
       subject.compileInForeground({

--- a/lib/__tests__/HappyThread.test.js
+++ b/lib/__tests__/HappyThread.test.js
@@ -6,17 +6,11 @@ const sinon = require('sinon');
 const fs = require('fs');
 
 describe("HappyThread", function() {
-  let subject;
-  let optionsFile, inputFile;
-
   const sandbox = sinon.sandbox.create();
 
-  beforeEach(function() {
-    optionsFile = createFile('happy-options.json', JSON.stringify({
-      loaders: [createLoader(s => s + 'he')],
-      compilerOptions: {}
-    }));
+  let subject, inputFile;
 
+  beforeEach(function() {
     inputFile = createFile('a.js', 'he');
   });
 
@@ -29,11 +23,7 @@ describe("HappyThread", function() {
   });
 
   it('works', function(done) {
-    subject = Subject('t1', {
-      tempDir: '/tmp',
-      optionsPath: optionsFile.getPath()
-    });
-
+    subject = Subject('t1');
     subject.open(function(err) {
       assert.ok(subject.isOpen());
 
@@ -41,27 +31,43 @@ describe("HappyThread", function() {
     });
   });
 
-  it('notifies me when a compilation is complete', function(done) {
-    subject = Subject('t1', {
-      tempDir: '/tmp',
-      optionsPath: optionsFile.getPath()
+  it('is configurable', function(done) {
+    subject = Subject('t1');
+    subject.open(function(err) {
+      if (err) { return done(err); }
+
+      subject.configure(JSON.stringify({ foo: 'bar' }), function(configureError) {
+        if (configureError) {
+          return done(configureError);
+        }
+
+        done();
+      });
     });
+  });
+
+  it('notifies me when a compilation is complete', function(done) {
+    subject = Subject('t1');
 
     subject.open(function(openError) {
       if (openError) return done(openError);
 
-      subject.compile({
-        compiledPath: tempPath('a.out'),
-        loaderContext: {
-          request: inputFile.getPath(),
-          resourcePath: inputFile.getPath()
-        }
-      }, function(result) {
-        assert.equal(result.error, undefined);
-        assert.equal(fs.readFileSync(tempPath('a.out'), 'utf-8'), 'hehe');
+      subject.configure("{}", function() {
+        subject.compile({
+          loaders: [createLoader(s => s + 'he')],
+          compiledPath: tempPath('a.out'),
+          loaderContext: {
+            request: inputFile.getPath(),
+            resourcePath: inputFile.getPath()
+          }
+        }, function(result) {
+          assert.equal(result.error, undefined);
+          assert.equal(fs.readFileSync(tempPath('a.out'), 'utf-8'), 'hehe');
 
-        done();
+          done();
+        });
       });
+
     });
   });
 });

--- a/lib/__tests__/HappyThreadPool.test.js
+++ b/lib/__tests__/HappyThreadPool.test.js
@@ -21,7 +21,7 @@ describe.skip("HappyThreadPool", function() {
       const loaders = [{ path: fixturePath('identity_loader.js') }];
       const options = {
         loaders,
-        compilerOptions: {}
+        compilerOptions: '{}'
       };
 
       fs.writeFileSync(tempPath('options.json'), JSON.stringify(options), 'utf-8');

--- a/lib/__tests__/HappyWorkerChannel.test.js
+++ b/lib/__tests__/HappyWorkerChannel.test.js
@@ -12,9 +12,22 @@ describe('HappyWorkerChannel', function() {
 
   let fd;
 
-  beforeEach(function() {
+  beforeEach(function(done) {
     fd = FakeProcess();
-    Channel('c1', fd.remote, { loaders, compilerOptions: {} });
+    fd.local.on('message', function(message) {
+      if (message.name === 'CONFIGURE_DONE') {
+        done();
+      }
+    });
+
+    Channel('c1', fd.remote);
+
+    fd.local.send({
+      name: 'CONFIGURE',
+      data: {
+        compilerOptions: '{}'
+      }
+    });
   });
 
   afterEach(function() {
@@ -35,6 +48,7 @@ describe('HappyWorkerChannel', function() {
     fd.local.send({
       name: 'COMPILE',
       data: {
+        loaders,
         compiledPath: tempPath('a.out'),
         loaderContext: {
           request: fixturePath('a.js'),
@@ -56,6 +70,7 @@ describe('HappyWorkerChannel', function() {
     fd.local.send({
       name: 'COMPILE',
       data: {
+        loaders,
         compiledPath: tempPath('a.out'),
         loaderContext: {
           request: fixturePath('a.js'),

--- a/lib/__tests__/integration/options__threadPool.test.js
+++ b/lib/__tests__/integration/options__threadPool.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { assert } = require('chai');
+const TestUtils = require('../../HappyTestUtils');
+const HappyPlugin = require('../../HappyPlugin');
+const webpack = require('webpack');
+
+describe('[Integration] config - @threadPool', function() {
+
+  context('when a custom thread pool is passed', function() {
+    const threadPool = HappyPlugin.ThreadPool({ size: 3, });
+
+    beforeEach(function(done) {
+      const sinon = TestUtils.getSinonSandbox();
+
+      HappyPlugin.resetUID();
+
+      sinon.spy(threadPool, 'start');
+      sinon.spy(threadPool, 'get');
+      sinon.spy(threadPool, 'stop');
+
+      const outputDir = TestUtils.tempDir('integration-[guid]');
+      const loader = TestUtils.createLoader(s => s);
+
+      const file1 = TestUtils.createFile('a.js', "require('./b.jsx')");
+      const file2 = TestUtils.createFile('b.jsx', "console.log('hello!');");
+
+      const compiler = webpack({
+        entry: {
+          main: [
+            file1.getPath(),
+            file2.getPath()
+          ]
+        },
+
+        output: {
+          filename: '[name].js',
+          path: outputDir
+        },
+
+        module: {
+          loaders: [{
+            test: /.js$/,
+            loader: TestUtils.HAPPY_LOADER_PATH
+          }, {
+            test: /.jsx$/,
+            loader: TestUtils.HAPPY_LOADER_PATH + '?id=jsx'
+          }]
+        },
+
+        plugins: [
+          new HappyPlugin({
+            cache: false,
+            loaders: [ loader.path ],
+            threadPool
+          }),
+
+          new HappyPlugin({
+            id: 'jsx',
+            cache: false,
+            loaders: [ loader.path ],
+            threadPool
+          })
+        ]
+      });
+
+      compiler.run(function(err, rawStats) {
+        if (TestUtils.assertNoWebpackErrors(err, rawStats, done)) {
+          return;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function() {
+      assert(!threadPool.isRunning());
+    })
+
+    it('waits until the pool is started', function() {
+      assert.calledTwice(threadPool.start);
+    });
+
+    it('uses it', function() {
+      assert.calledTwice(threadPool.get);
+    });
+
+    it('stops the pool when it is done', function() {
+      assert.calledTwice(threadPool.stop);
+    });
+  });
+});

--- a/lib/fnOnce.js
+++ b/lib/fnOnce.js
@@ -12,6 +12,6 @@ function Once(fn) {
   }
 }
 
-Once.ALREADY_CALLED = Object.freeze('Once.ALREADY_CALLED');
+Once.ALREADY_CALLED = Object.freeze({});
 
 module.exports = Once;


### PR DESCRIPTION
Multiple Happy plugin instances can now share the same thread pool. Very effective when some instances have way fewer files than others in which case their threads used to be idle most of the time.