### PR TITLE
this.emitFile() and re-introduced loader inference

### DIFF
--- a/lib/HappyFSCache.js
+++ b/lib/HappyFSCache.js
@@ -12,7 +12,7 @@ var assert = require('assert');
  *        be stored. Path must be writable.
  *
  */
-module.exports = function HappyFSCache(id, cachePath) {
+module.exports = function HappyFSCache(id, cachePath, verbose) {
   var exports = {};
   var cache = { context: {}, mtimes: {} };
 
@@ -39,14 +39,20 @@ module.exports = function HappyFSCache(id, cachePath) {
       "HappyFSCache requires a @context parameter to work.");
 
     if (!Utils.isReadable(cachePath)) {
-      console.log('Happy[%s]: No cache was found, starting fresh.', id);
+      if (verbose) {
+        console.log('Happy[%s]: No cache was found, starting fresh.', id);
+      }
+
       return false;
     }
 
     oldCache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
 
     if (toJSON(oldCache.context) !== toJSON(currentContext)) {
-      console.log('Happy[%s]: Cache is no longer valid, starting fresh.', id);
+      if (verbose) {
+        console.log('Happy[%s]: Cache is no longer valid, starting fresh.', id);
+      }
+
       return false;
     }
 
@@ -55,9 +61,11 @@ module.exports = function HappyFSCache(id, cachePath) {
 
     staleEntryCount = removeStaleEntries(cache.mtimes);
 
-    console.log('Happy[%s]: Loaded %d entries from cache. (%d were stale)',
-      id, Object.keys(cache.mtimes).length, staleEntryCount
-    );
+    if (verbose) {
+      console.log('Happy[%s]: Loaded %d entries from cache. (%d were stale)',
+        id, Object.keys(cache.mtimes).length, staleEntryCount
+      );
+    }
 
     return true;
   };

--- a/lib/HappyFakeLoaderContext.js
+++ b/lib/HappyFakeLoaderContext.js
@@ -70,6 +70,15 @@ function HappyFakeLoaderContext(initialValues) {
     });
   };
 
+  loader.emitFile = function(name, contents, sourceMap) {
+    loader._compiler._sendMessage('emitFile', {
+      remoteLoaderId: loader._remoteLoaderId,
+      name: name,
+      contents: contents,
+      sourceMap: JSON.stringify(sourceMap || {})
+    });
+  };
+
   // alias
   loader.dependency = loader.addDependency;
 

--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -37,8 +37,10 @@ function HappyPlugin(userConfig) {
     cache:              { type: 'boolean', default: true },
     cacheContext:       { default: {} },
     cachePath:          { type: 'string' },
-
-    loaders: {
+    inferLoaders:       { type: 'boolean', default: false },
+    verbose:            { type: 'boolean', default: true },
+    enabled:            { type: 'boolean', default: true },
+    loaders:            {
       validate: function(value) {
         if (!Array.isArray(value)) {
           return 'Loaders must be an array!';
@@ -52,7 +54,6 @@ function HappyPlugin(userConfig) {
           return 'Loader must have a @path property or be a string.'
         }
       },
-      isRequired: true,
     }
   }, "HappyPack[" + this.id + "]");
 
@@ -61,8 +62,9 @@ function HappyPlugin(userConfig) {
   });
 
   this.cache = HappyFSCache(this.id, this.config.cachePath ?
-    path.resolve(this.config.cachePath) :
-    path.resolve(this.config.tempDir, 'cache--' + this.id + '.json')
+    path.resolve(this.config.cachePath.replace(/\[id\]/g, this.id)) :
+    path.resolve(this.config.tempDir, 'cache--' + this.id + '.json'),
+    this.config.verbose
   );
 
   HappyUtils.mkdirSync(this.config.tempDir);
@@ -75,8 +77,11 @@ HappyPlugin.resetUID = function() {
 };
 
 HappyPlugin.prototype.apply = function(compiler) {
-  var that = this;
+  if (this.config.enabled === false) {
+    return;
+  }
 
+  var that = this;
   var engageWatchMode = fnOnce(function() {
     // Once the initial build has completed, we create a foreground worker and
     // perform all compilations in this thread instead:
@@ -116,12 +121,14 @@ HappyPlugin.prototype.start = function(compiler, done) {
 
   assert(!that.state.started, "HappyPlugin has already been started!");
 
-  console.log('Happy[%s]: Version: %s. Using cache? %s. Threads: %d%s',
-    that.id, pkg.version,
-    that.config.cache ? 'yes' : 'no',
-    that.threadPool.size,
-    that.config.threadPool ? ' (shared pool)' : ''
-  );
+  if (that.config.verbose) {
+    console.log('Happy[%s]: Version: %s. Using cache? %s. Threads: %d%s',
+      that.id, pkg.version,
+      that.config.cache ? 'yes' : 'no',
+      that.threadPool.size,
+      that.config.threadPool ? ' (shared pool)' : ''
+    );
+  }
 
   async.series([
     function registerCompilerForRPCs(callback) {
@@ -131,7 +138,29 @@ HappyPlugin.prototype.start = function(compiler, done) {
     },
 
     function normalizeLoaders(callback) {
-      that.state.loaders = that.config.loaders
+      var loaders = that.config.loaders;
+
+      // if no loaders are configured, try to infer from existing module.loaders
+      // list if any entry has a "{ happy: { id: ... } }" object
+      if (!loaders) {
+        var sourceLoaderConfig = compiler.options.module.loaders.filter(function(loader) {
+          return loader.happy && loader.happy.id === that.id;
+        })[0];
+
+        if (sourceLoaderConfig) {
+          loaders = sourceLoaderConfig.loaders || [ sourceLoaderConfig.loader ];
+
+          // yeah, yuck... we need to overwrite, ugly!
+          sourceLoaderConfig.loader = path.resolve(__dirname, 'HappyLoader.js') + '?id=' + that.id;
+        }
+      }
+
+      assert(loaders,
+        "HappyPlugin[" + that.id + "]; you have not specified any loaders " +
+        "and there is no matching loader entry with this id either."
+      );
+
+      that.state.loaders = loaders
         .map(WebpackUtils.disectLoaderString)
         .reduce(function(allLoaders, loadersFoundInString) {
           return allLoaders.concat(loadersFoundInString);

--- a/lib/HappyRPCHandler.js
+++ b/lib/HappyRPCHandler.js
@@ -34,6 +34,9 @@ HappyRPCHandler.execute = function(type, payload, done) {
     else if (type === 'emitError') {
       loader.emitError(payload.message);
     }
+    else if (type === 'emitFile') {
+      loader.emitFile(payload.name, payload.contents, JSON.parse(payload.sourceMap));
+    }
     else if (type === 'addDependency') {
       loader.addDependency(payload.file);
     }

--- a/lib/__tests__/integration/RPC--Loader__emitFile.test.js
+++ b/lib/__tests__/integration/RPC--Loader__emitFile.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const webpack = require('webpack');
+const HappyPlugin = require('../../HappyPlugin');
+const TestUtils = require('../../HappyTestUtils');
+const { assert, } = require('../../HappyTestUtils');
+
+describe('[Integration] Loader RPCs - this.emitFile()', function() {
+  TestUtils.IntegrationSuite(this);
+
+  it('works', function(done) {
+    const sinon = TestUtils.getSinonSandbox();
+    const loader = TestUtils.createLoader(function(s) {
+      this.emitFile('b.js', 'foo', { 1: 'zxc' });
+
+      return s;
+    });
+
+    TestUtils.spyOnActiveLoader(happyLoader => {
+      sinon.spy(happyLoader, 'emitFile');
+    });
+
+    const compiler = webpack({
+      entry: TestUtils.createFile('a.js', '// a.js').getPath(),
+      output: {
+        path: TestUtils.tempDir('integration-[guid]')
+      },
+
+      module: {
+        loaders: [{
+          test: /.js$/,
+          loader: TestUtils.HAPPY_LOADER_PATH
+        }]
+      },
+
+      plugins: [
+        new HappyPlugin({
+          loaders: [ loader.path ],
+        })
+      ]
+    });
+
+    compiler.run(function(err, rawStats) {
+      TestUtils.assertNoWebpackErrors(err, rawStats, done);
+
+      assert.calledWith(TestUtils.activeLoader.emitFile, 'b.js', 'foo', { 1: 'zxc' });
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
- support for `file-loader` which uses `this.emitFile()`
- loaders can now be inferred once more by supplying
    { happy: { id: '...' }  }
- a happy plugin can be disabled by passing { enabled: false } to its
  config, useful for env variable-based control