### PR TITLE
Remove assert if already running

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -119,8 +119,6 @@ HappyPlugin.prototype.apply = function(compiler) {
 HappyPlugin.prototype.start = function(compiler, done) {
   var that = this;
 
-  assert(!that.state.started, "HappyPlugin has already been started!");
-
   if (that.config.verbose) {
     console.log('Happy[%s]: Version: %s. Using cache? %s. Threads: %d%s',
       that.id, pkg.version,


### PR DESCRIPTION
Using `grunt-webpack` with `grunt-contrib-watch` causes the "HappyPlugin has already been started!" message and hang the 2nd time it runs. Removing the assert fixes the issue but let me know if there is a better way...

p.s. great work on this!