### PR TITLE
Making the cache loader and SourceMapSerializer a bit more bullet proof

### DIFF
--- a/lib/HappyFSCache.js
+++ b/lib/HappyFSCache.js
@@ -51,9 +51,13 @@ module.exports = function HappyFSCache(config) {
       return false;
     }
 
-    oldCache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    try {
+      oldCache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+    } catch(e) {
+      oldCache = null;
+    }
 
-    if (toJSON(oldCache.context) !== toJSON(currentContext)) {
+    if (currentContext && toJSON(oldCache.context) !== toJSON(currentContext)) {
       if (config.verbose) {
         console.log('Happy[%s]: Cache is no longer valid, starting fresh.', id);
       }

--- a/lib/HappyFSCache.js
+++ b/lib/HappyFSCache.js
@@ -57,7 +57,7 @@ module.exports = function HappyFSCache(config) {
       oldCache = null;
     }
 
-    if (currentContext && toJSON(oldCache.context) !== toJSON(currentContext)) {
+    if (oldCache && toJSON(oldCache.context) !== toJSON(currentContext)) {
       if (config.verbose) {
         console.log('Happy[%s]: Cache is no longer valid, starting fresh.', id);
       }

--- a/lib/HappyFSCache.js
+++ b/lib/HappyFSCache.js
@@ -57,7 +57,7 @@ module.exports = function HappyFSCache(config) {
       oldCache = null;
     }
 
-    if (oldCache && toJSON(oldCache.context) !== toJSON(currentContext)) {
+    if (!oldCache || toJSON(oldCache.context) !== toJSON(currentContext)) {
       if (config.verbose) {
         console.log('Happy[%s]: Cache is no longer valid, starting fresh.', id);
       }

--- a/lib/SourceMapSerializer.js
+++ b/lib/SourceMapSerializer.js
@@ -9,9 +9,11 @@ exports.serialize = function(x) {
 
 exports.deserialize = function(x) {
   if (typeof x === 'string') {
-    return JSON.parse(x);
+    try {
+      return JSON.parse(x);
+    } catch (e) {
+      return x || null;
+    }
   }
-  else {
-    return x || null;
-  }
+  return x || null;
 };

--- a/lib/SourceMapSerializer.js
+++ b/lib/SourceMapSerializer.js
@@ -12,7 +12,7 @@ exports.deserialize = function(x) {
     try {
       return JSON.parse(x);
     } catch (e) {
-      return x || null;
+      return null;
     }
   }
   return x || null;


### PR DESCRIPTION
Sometimes get `Unexpected end of input` when running in our teams build system so these changes should handle JSON parsing errors.