### PR TITLE
Fixes #44 with temporary workaround for webpack2 watch

### DIFF
--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -11,6 +11,7 @@ function HappyLoader(sourceCode, sourceMap) {
 
   this.cacheable();
 
+  if (!this.options.plugins) return callback(null, sourceCode, sourceMap);
   happyPlugin = this.options.plugins.filter(isHappy(id))[0];
 
   assert(!!happyPlugin,


### PR DESCRIPTION
I've commented the Loader hack, so that way when changes are made to fully support Webpack 2 the code can be easily removed, but in the meantime it won't error out.