### PR TITLE
Additional config.verbose check for startup message

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -228,7 +228,9 @@ HappyPlugin.prototype.start = function(compiler, done) {
     },
 
     function markStarted(callback) {
-      console.log('Happy[%s]: All set; signalling webpack to proceed.', that.id);
+      if (that.config.verbose) {
+        console.log('Happy[%s]: All set; signalling webpack to proceed.', that.id);
+      }
 
       that.state.started = true;
 


### PR DESCRIPTION
Great library! Reduced our webpack build times by 200%

Our app has a lot of console messages on startup and it can get a bit cluttered with all the happypack logs, so I'm hoping to keep them hidden if config.verbose is set to false :)