### PR TITLE
Allow single worker to process same file/params more than once

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -15,6 +15,7 @@ var SourceMapSerializer = require('./SourceMapSerializer');
 var fnOnce = require('./fnOnce');
 var pkg = require('../package.json');
 var uid = 0;
+var uniqIds = {};
 
 function HappyPlugin(userConfig) {
   if (!(this instanceof HappyPlugin)) {
@@ -300,6 +301,8 @@ HappyPlugin.prototype.compileInForeground = function(loaderContext, done) {
 HappyPlugin.prototype._performCompilationRequest = function(worker, loaderContext, done) {
   var cache = this.cache;
   var filePath = loaderContext.resourcePath;
+  uniqIds[loaderContext.resourcePath] = uniqIds[loaderContext.resourcePath] || 0;
+  uniqIds[loaderContext.resourcePath] += 1;
 
   cache.invalidateEntryFor(filePath);
 
@@ -307,6 +310,7 @@ HappyPlugin.prototype._performCompilationRequest = function(worker, loaderContex
     loaders: this.state.loaders,
     compiledPath: path.resolve(this.config.tempDir, HappyUtils.generateCompiledPath(filePath)),
     loaderContext: loaderContext,
+    uniqId: uniqIds[loaderContext.resourcePath],
   }, function(result) {
     var contents = fs.readFileSync(result.compiledPath, 'utf-8')
     var compiledMap;

--- a/lib/HappyThread.js
+++ b/lib/HappyThread.js
@@ -36,16 +36,17 @@ function HappyThread(id) {
         }
         else if (message.name === 'COMPILED') {
           var filePath = message.sourcePath;
+          var callbackKey = message.uniqId + ':' + filePath;
 
           HappyLogger.info('Thread[%d]: a file has been compiled.', id, filePath);
 
-          assert(typeof callbacks[filePath] === 'function',
+          assert(typeof callbacks[callbackKey] === 'function',
             "HappyThread: expected loader to be pending on source file '" +
             filePath + "'" + " (this is likely an internal error!)"
           );
 
-          callbacks[filePath](message);
-          delete callbacks[filePath];
+          callbacks[callbackKey](message);
+          delete callbacks[callbackKey];
         }
         else if (message.name === 'COMPILER_REQUEST') {
           HappyLogger.debug('forwarding compiler request from worker to plugin:', message);
@@ -97,7 +98,7 @@ function HappyThread(id) {
 
       assert(!!fd, "You must launch a compilation thread before attemping to use it!!!");
 
-      callbacks[params.loaderContext.resourcePath] = done;
+      callbacks[params.uniqId + ':' + params.loaderContext.resourcePath] = done;
 
       fd.send({
         name: 'COMPILE',

--- a/lib/HappyWorkerChannel.js
+++ b/lib/HappyWorkerChannel.js
@@ -26,7 +26,8 @@ function HappyWorkerChannel(id, stream) {
           name: 'COMPILED',
           sourcePath: result.sourcePath,
           compiledPath: result.compiledPath,
-          success: result.success
+          success: result.success,
+          uniqId: message.data.uniqId
         });
       });
     }


### PR DESCRIPTION
# What
Add more data to the key used to track compilation progress for each file inside each worker, so that if the same file comes through twice the callback is not confused

# Why
Currently if the same file gets compiled twice and ends up being sent to the same thread the plugin will break. This PR allows the same thread to compile the same file twice without breaking