### PR TITLE
Allow option 'plugins' to be a function in HappyLoader

### DIFF
--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -11,8 +11,8 @@ function HappyLoader(sourceCode, sourceMap) {
 
   this.cacheable();
   
-  if (typeof this.options.plugins === 'function') {
-      this.options.plugins = this.options.plugins();
+  if(typeof this.options.plugins === 'function') {
+    this.options.plugins = this.options.plugins();
   }
 
   if (!this.options.plugins) {

--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -10,7 +10,7 @@ function HappyLoader(sourceCode, sourceMap) {
   assert(callback, "HappyPack only works when asynchronous loaders are allowed!");
 
   this.cacheable();
-  
+
   if(typeof this.options.plugins === 'function') {
     this.options.plugins = this.options.plugins();
   }

--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -10,6 +10,10 @@ function HappyLoader(sourceCode, sourceMap) {
   assert(callback, "HappyPack only works when asynchronous loaders are allowed!");
 
   this.cacheable();
+  
+  if (typeof this.options.plugins === 'function') {
+      this.options.plugins = this.options.plugins();
+  }
 
   if (!this.options.plugins) {
     return callback(null, sourceCode, sourceMap);


### PR DESCRIPTION
Hello,
I made it available to make 'plugins' in HappyLoader a function.

It may be useful for integration with webpack >= 2.1.0-beta.23 which has a new mechanism of loading options with LoaderOptionsPlugin

If we define LoaderOptionsPlugin as:
```
var plugins = [ new webpack.LoaderOptionsPlugin({
        options: {
            plugins: function () {return plugins;}
        },
    })
    ...
];

module.exports = {
    entry: entries,
    plugins: plugins
    ...
};
```
`plugins` will be available in HappyLoader, and HappyPack won't be broken. 