### PR TITLE
Start threadpool ASAP

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -12,6 +12,7 @@ var JSONSerializer = require('./JSONSerializer');
 var SourceMapSerializer = require('./SourceMapSerializer');
 var fnOnce = require('./fnOnce');
 var pkg = require('../package.json');
+var NoOp = Function.prototype;
 
 function HappyPlugin(userConfig) {
   if (!(this instanceof HappyPlugin)) {
@@ -84,6 +85,8 @@ HappyPlugin.prototype.apply = function(compiler) {
     verbose: this.state.verbose,
     debug: this.state.debug,
   });
+
+  this.threadPool.start(NoOp);
 
   this.cache = HappyFSCache({
     id: this.id,
@@ -192,6 +195,31 @@ HappyPlugin.prototype.start = function(compiler, done) {
       callback();
     },
 
+    function waitForThreadPool(callback) {
+      if (that.threadPool.isRunning()) {
+        callback();
+      }
+      else {
+        var timer;
+        var frequency = 3;
+        var checkAgain = function() {
+          if (that.state.verbose) {
+            console.log('Happy[%s] Waiting for threadpool to start...', that.id);
+          }
+
+          if (that.threadPool.isRunning()) {
+            timer = clearTimeout(timer);
+            callback();
+          }
+          else {
+            setTimeout(checkAgain, frequency)
+          }
+        }
+
+        timer = setTimeout(checkAgain, frequency)
+      }
+    },
+
     function launchAndConfigureThreads(callback) {
       var serializedOptions;
       var compilerOptions = HappyPlugin.extractCompilerOptions(compiler.options);
@@ -206,7 +234,7 @@ HappyPlugin.prototype.start = function(compiler, done) {
         return callback(e);
       }
 
-      that.threadPool.start(that.config.compilerId, compiler, serializedOptions, callback);
+      that.threadPool.configure(that.config.compilerId, compiler, serializedOptions, callback);
     },
 
     function markStarted(callback) {

--- a/lib/HappyThreadPool.js
+++ b/lib/HappyThreadPool.js
@@ -44,24 +44,28 @@ module.exports = function HappyThreadPool(config) {
   return {
     size: config.size,
 
-    start: function(compilerId, compiler, compilerOptions, done) {
-      rpcHandler.registerActiveCompiler(compilerId, compiler);
-
+    start: function(done) {
       async.parallel(threads.filter(not(send('isOpen'))).map(get('open')), function(err) {
         if (err) {
           return done(err);
         }
 
-        async.parallel(threads.map(function(thread) {
-          return function(callback) {
-            thread.configure(compilerId, compilerOptions, callback);
-          }
-        }), done);
+        done();
       });
     },
 
     isRunning: function() {
       return !threads.some(not(send('isOpen')));
+    },
+
+    configure: function(compilerId, compiler, compilerOptions, done) {
+      rpcHandler.registerActiveCompiler(compilerId, compiler);
+
+      async.parallel(threads.map(function(thread) {
+        return function(callback) {
+          thread.configure(compilerId, compilerOptions, callback);
+        }
+      }), done);
     },
 
     compile: function(loaderId, loader, params, done) {

--- a/lib/__tests__/HappyThreadPool.test.js
+++ b/lib/__tests__/HappyThreadPool.test.js
@@ -24,10 +24,15 @@ describe("HappyThreadPool", function() {
 
       var compiler = {};
 
-      subject.start('default', compiler, '{}', function(e) {
-        assert.ok(subject.isRunning());
+      subject.start(function(err) {
+        if (err) {
+          return done(err);
+        }
+        subject.configure('default', compiler, '{}', function(e) {
+          assert.ok(subject.isRunning());
 
-        done(e);
+          done(e);
+        });
       });
     });
   });


### PR DESCRIPTION
Instead of waiting for the compiler to start for us to launch the
threads, we can do it as soon as the plugin is instantiated and in case
the compiler is ready before the threadpool is, we wait for it and then
proceed.

Granted, this doesn't seem to buy any time on Linux (at least on my
machine) but https://github.com/jhnns/happypack-perf-test and GH-111
indicate that it may buy time on other OSes.

Let's hope it does!