### PR TITLE
Modifying the code does not produce new cache files

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -340,11 +340,9 @@ function compileAndUpdateCache(threadPool, loader, loaderContext, done) {
   var cache = this.cache;
   var filePath = loaderContext.resourcePath;
 
-  cache.invalidateEntryFor(filePath);
-
   threadPool.compile(loaderContext.remoteLoaderId, loader, {
     loaders: this.state.loaders,
-    compiledPath: path.resolve(this.config.tempDir, HappyUtils.generateCompiledPath(filePath)),
+    compiledPath: path.resolve(this.config.tempDir, cache.getCompiledSourceCodePath(filePath) || HappyUtils.generateCompiledPath(filePath)),
     loaderContext: loaderContext,
   }, function(result) {
     var contents = fs.readFileSync(result.compiledPath, 'utf-8')


### PR DESCRIPTION
When I was coding, I found that the '.happypack' folder would add new cache files but not deleting old ones. So I want to know why not just overwrite the old files which already expired? 
@amireh 