### PR TITLE
Include request property in loaders

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -172,7 +172,14 @@ HappyPlugin.prototype.start = function(compiler, done) {
       WebpackUtils.resolveLoaders(compiler, loaderPaths, function(err, loaders) {
         if (err) return callback(err);
 
-        that.state.loaders = loaders;
+        that.state.loaders = loaders.map(function(loader) {
+          if (!loader.request) {
+            loader.request = (loader.query) ? loader.path + loader.query : loader.path;
+          };
+
+          return loader;
+        });
+
         that.state.baseLoaderRequest = loaders.map(function(loader) {
           return loader.path + (loader.query || '');
         }).join('!');

--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -175,7 +175,7 @@ HappyPlugin.prototype.start = function(compiler, done) {
         that.state.loaders = loaders.map(function(loader) {
           if (!loader.request) {
             loader.request = (loader.query) ? loader.path + loader.query : loader.path;
-          };
+          }
 
           return loader;
         });


### PR DESCRIPTION
For some reason the resolver for the less loader and possibly the postcss loader resolver based on #109 and possibly the sass loader resolver from #95 return loader objects with only the path and query property but the css loader uses the request property of the loader which is just the concatenation of path and query.