### PR TITLE
Avoid unnecessary query parsing in WebpackUtils.resolveLoaders

### DIFF
--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -162,25 +162,19 @@ HappyPlugin.prototype.start = function(compiler, done) {
 
     function resolveLoaders(callback) {
       var loaderPaths = that.state.loaders.map(function(loader) {
-        if (loader.query) {
-          return loader.path + loader.query;
-        }
-
         return loader.path;
       });
 
-      WebpackUtils.resolveLoaders(compiler, loaderPaths, function(err, loaders) {
+      WebpackUtils.resolveLoaders(compiler, loaderPaths, function(err, resolvedPaths) {
         if (err) return callback(err);
 
-        that.state.loaders = loaders.map(function(loader) {
-          if (!loader.request) {
-            loader.request = (loader.query) ? loader.path + loader.query : loader.path;
-          }
-
-          return loader;
+        resolvedPaths.forEach(function (resolvedPath, index) {
+          var loader = that.state.loaders[index];
+          loader.path = resolvedPath;
+          loader.request = (loader.query) ? loader.path + loader.query : loader.path;
         });
 
-        that.state.baseLoaderRequest = loaders.map(function(loader) {
+        that.state.baseLoaderRequest = that.state.loaders.map(function(loader) {
           return loader.path + (loader.query || '');
         }).join('!');
 

--- a/lib/WebpackUtils.js
+++ b/lib/WebpackUtils.js
@@ -137,7 +137,7 @@ exports.resolveLoaders = function(compiler, loaders, done) {
           return callback(err);
         }
 
-        callback(null, extractPathAndQueryFromString(result));
+        callback(null, result);
       }];
 
       if (isWebpack2) {

--- a/lib/__tests__/WebpackUtils.test.js
+++ b/lib/__tests__/WebpackUtils.test.js
@@ -18,19 +18,7 @@ describe('WebpackUtils', function() {
         if (err) return done(err);
 
         assert.equal(loaders.length, 1);
-        assert.equal(loaders[0].path, fakeLoader.path);
-
-        done();
-      });
-    });
-
-    it('resolves the full path and query of a loader', function(done) {
-      runWithLoaders([{ test: /.js$/, loader: 'babel?presets[]=es2015' }], function(err, loaders) {
-        if (err) return done(err);
-
-        assert.equal(loaders.length, 1);
-        assert.equal(loaders[0].path, fakeLoader.path);
-        assert.equal(loaders[0].query, '?presets[]=es2015');
+        assert.equal(loaders[0], fakeLoader.path);
 
         done();
       });


### PR DESCRIPTION
This PR fixes a bug when the user provides an object query that when stringified, contains the char `!`. For example:

``` js
plugins: [
  new HappyPack({
    loaders: [{
      path: 'vue-loader',
      query: {
        loaders: {
          scss: 'vue-style-loader!css-loader!sass-loader?indentedSyntax'
        }
      }
    }]
  })
]
```

After stringification, the whole loader string (including the query) passed to `compiler.resolvers.loader.resolve` is:

```
vue-loader?{"loaders":{"scss":"vue-style-loader!css-loader!sass-loader?indentedSyntax"}}
```

After resolve, the following is then passed to `extractPathAndQueryFromString` ([L140](https://github.com/amireh/happypack/blob/master/lib/WebpackUtils.js#L140)):

```
/absolute/path/to/vue-loader?{"loaders":{"scss":"vue-style-loader!css-loader!sass-loader?indentedSyntax"}}
```

Now because the string contains `!` which is actually part of the query rather than a multi-loader delimiter, the parse result is wrong.

However, it is unnecessary to pass the query along to the resolver in the first place. So simply avoiding that would solve the problem.

---

Note: merging this would largely resolve #83.