### PR TITLE
Support for loader API .minimize

### DIFF
--- a/lib/HappyFakeLoaderContext.js
+++ b/lib/HappyFakeLoaderContext.js
@@ -30,6 +30,7 @@ function HappyFakeLoaderContext(initialValues) {
   loader.sourceMap = false;
   loader.fs = null;
   loader.target = 'web';
+  loader.minimize = undefined; // keep it as undefined by default just like without happypack, to make sure there is no accident...
 
   // TODO
   loader.cacheable = function() {};

--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -55,6 +55,7 @@ function HappyLoader(sourceCode, sourceMap) {
     resourcePath: this.resourcePath,
     resourceQuery: this.resourceQuery,
     target: this.target,
+    minimize: this.minimize,
   }, callback);
 }
 

--- a/lib/applyLoaders.js
+++ b/lib/applyLoaders.js
@@ -103,6 +103,7 @@ module.exports = function applyLoaders(runContext, sourceCode, sourceMap, done) 
 
         sourceMap: Boolean(runContext.loaderContext.useSourceMap),
         target: runContext.loaderContext.target,
+        minimize: runContext.loaderContext.minimize,
       })
     };
   });


### PR DESCRIPTION
While [the wiki page says HappyPack supports .minimize Loader API](https://github.com/amireh/happypack/wiki/Webpack-Loader-API-Support), it actually doesn't.

Submit changes to add ".minimize" support.

This option is used by a common-used plugin "webpack.optimize.UglifyJsPlugin", which sets `context.minimize = true`, ([check the code here](https://github.com/webpack/webpack/blob/v1.14.0/lib/optimize/UglifyJsPlugin.js#L142-L144)). Missing this support, css cannot get minified correctly.
