### PR TITLE
Fix spelling mistake of HappyThread.js

### DIFF
--- a/lib/HappyThread.js
+++ b/lib/HappyThread.js
@@ -127,7 +127,7 @@ function HappyThread(id, happyRPCHandler, config) {
       assert(params.compiledPath && typeof params.compiledPath === 'string');
       assert(params.loaderContext && typeof params.loaderContext === 'object');
 
-      assert(!!fd, "You must launch a compilation thread before attemping to use it!!!");
+      assert(!!fd, "You must launch a compilation thread before attempting to use it!!!");
 
       callbacks[messageId] = done;
 


### PR DESCRIPTION
Change 'attemping' to 'attempting'.