### PR TITLE
buffer process.send() calls on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,54 @@
 ## HappyPack Changelog
 
-### 4.0.0
+### 4.0.0-beta.3
+
+Fixed bug around the use of `process.send()` that was causing a hang on
+Windows with sufficiently large number of modules (and message length.)
+
+The following parse (on Linux) shows the penalty in buffered vs non-buffered
+modes and implementations:
+
+elapsed (ms) | buffering | mean (ms) | penalty (ms)
+------------ | --------- | --------- | ------------
+22211        | none
+21816
+22572
+21179
+21035        |           | 21762.6   | 0
+21723        | basic
+22585
+23372
+22500
+22693        |           | 22574.6   | 812
+24865        | async.queue
+23010
+22717
+23530
+23732        |           | 23570.8   | 1808
+21363        | basic + process.nextTick
+22220
+21901
+21871
+22306        |           | 21932.2   | 170
+23349        | basic (again)
+22043
+21904
+23435
+23508        |           | 22847.8   | 1085
+22735        | basic + process.nextTick (again)
+21793
+22412
+21900
+22656        |           | 22299.2   | 537
+
+### 4.0.0-beta.2
+
+- Errors are now property serialized in `emitWarning` and `emitError` loader
+  APIs. Refs GH-161
+- Deprecation upgrade: now using `loaderUtils.getOptions` instead of
+  `.parseQuery`, refs GH-140
+
+### 4.0.0-beta.1
 
 - Support for file-system caching has been dropped. Use [cache-
   loader](https://github.com/webpack-contrib/cache-loader) if you're after this

--- a/lib/BufferedFd.js
+++ b/lib/BufferedFd.js
@@ -1,0 +1,36 @@
+var BufferedFd = exports
+
+BufferedFd.of = function(fd) {
+  return {
+    descriptor: fd,
+    queue: [],
+  }
+}
+
+BufferedFd.send = function(fd, message, callback) {
+  fd.queue.push([ message, callback ]);
+
+  if (fd.queue.length === 1) {
+    deliver(fd)
+  }
+}
+
+BufferedFd.discard = function(fd) {
+  fd.queue.splice(0)
+}
+
+function deliver(fd) {
+  var item = fd.queue[0]
+
+  fd.descriptor.send(item[0], undefined, undefined, function(err) {
+    fd.queue.shift()
+
+    item[1](err)
+
+    process.nextTick(function() {
+      if (fd.queue.length) {
+        deliver(fd)
+      }
+    })
+  })
+}

--- a/lib/BufferedFd.js
+++ b/lib/BufferedFd.js
@@ -1,3 +1,4 @@
+var processSend = require('./processSend')
 var BufferedFd = exports
 
 BufferedFd.of = function(fd) {
@@ -22,7 +23,7 @@ BufferedFd.discard = function(fd) {
 function deliver(fd) {
   var item = fd.queue[0]
 
-  fd.descriptor.send(item[0], undefined, undefined, function(err) {
+  processSend(fd.descriptor, item[0], function(err) {
     fd.queue.shift()
 
     item[1](err)

--- a/lib/HappyPlugin.js
+++ b/lib/HappyPlugin.js
@@ -9,6 +9,7 @@ var fnOnce = require('./fnOnce');
 var ErrorSerializer = require('./ErrorSerializer');
 var pick = require('./pick');
 var pkg = require('../package.json');
+var os = require('os');
 
 function HappyPlugin(userConfig) {
   if (!(this instanceof HappyPlugin)) {
@@ -38,6 +39,10 @@ function HappyPlugin(userConfig) {
     verboseWhenProfiling:     { type: 'boolean', default: false },
     debug:                    { type: 'boolean', default: process.env.DEBUG === '1' },
     enabled:                  { deprecated: true },
+    // we don't want this to be documented / exposed since it's an
+    // implementation detail + not having it on means a bug, but we're making it
+    // configurable for testing purposes
+    bufferedMessaging:        { type: 'boolean', default: os.platform() === 'win32' },
     loaders:                  {
       validate: function(value) {
         if (!Array.isArray(value)) {
@@ -73,6 +78,7 @@ HappyPlugin.prototype.apply = function(compiler) {
     size: this.config.threads,
     verbose: this.state.verbose,
     debug: this.state.debug,
+    bufferedMessaging: this.config.bufferedMessaging,
   });
 
   engageWatchMode = fnOnce(function() {

--- a/lib/HappyThread.js
+++ b/lib/HappyThread.js
@@ -3,17 +3,20 @@ var fork = require('child_process').fork;
 var assert = require('assert');
 var Once = require('./fnOnce');
 var WORKER_BIN = path.resolve(__dirname, 'HappyWorkerChannel.js');
+var BufferedFd = require('./BufferedFd')
+var UnbufferedFd = require('./UnbufferedFd')
 
 /**
  * @param {String|Number} id
  * @param {Object?} config
  * @param {Boolean} [config.verbose=false]
  * @param {Boolean} [config.debug=false]
+ * @param {Boolean} [config.buffered=false]
  */
-function HappyThread(id, happyRPCHandler, config) {
-  config = config || {};
-
-  var fd;
+function HappyThread(id, happyRPCHandler, _config) {
+  var fd, bfd;
+  var config = _config || {};
+  var BufferedFdImpl = config.buffered ? BufferedFd : UnbufferedFd;
   var callbacks = {};
   var generateMessageId = (function() {
     var counter = 0;
@@ -25,15 +28,25 @@ function HappyThread(id, happyRPCHandler, config) {
     }
   }());
 
+  var logSendError = function(err) {
+    if (err) {
+      console.error('HappyThread[%s]: unable to send to worker!', id, err)
+    }
+  }
+
+  var send = function(message) {
+    BufferedFdImpl.send(bfd, message, logSendError)
+  }
+
   return {
     open: function(onReady) {
       var emitReady = Once(onReady);
 
-      fd = fork(WORKER_BIN, [id], {
+      fd = fork(WORKER_BIN, [id, JSON.stringify({ buffered: config.buffered })], {
         // Do not pass through any arguments that were passed to the main
         // process (webpack or node) because they could have unwanted
         // side-effects, see issue #47
-        execArgv: []
+        execArgv: [],
       });
 
       fd.on('error', throwError);
@@ -43,7 +56,9 @@ function HappyThread(id, happyRPCHandler, config) {
         }
       });
 
-      fd.on('message', function acceptMessageFromWorker(message) {
+      bfd = BufferedFdImpl.of(fd)
+
+      fd.on('message', function(message) {
         if (message.name === 'READY') {
           if (config.debug) {
             console.info('HappyThread[%s] is now open.', id);
@@ -78,7 +93,7 @@ function HappyThread(id, happyRPCHandler, config) {
 
           // TODO: DRY alert, see .createForegroundWorker() in HappyPlugin.js
           happyRPCHandler.execute(message.data.type, message.data.payload, function(error, result) {
-            fd.send({
+            send({
               id: message.id, // downstream id
               name: 'COMPILER_RESPONSE',
               data: {
@@ -99,7 +114,7 @@ function HappyThread(id, happyRPCHandler, config) {
 
       callbacks[messageId] = done;
 
-      fd.send({
+      send({
         id: messageId,
         name: 'CONFIGURE',
         data: {
@@ -128,7 +143,7 @@ function HappyThread(id, happyRPCHandler, config) {
         console.log('HappyThread[%s]: compiling "%s"... (request=%s)', id, params.loaderContext.resourcePath, messageId);
       }
 
-      fd.send({
+      send({
         id: messageId,
         name: 'COMPILE',
         data: params,
@@ -140,6 +155,10 @@ function HappyThread(id, happyRPCHandler, config) {
     },
 
     close: function() {
+      BufferedFdImpl.discard(bfd);
+
+      bfd = null;
+
       fd.kill('SIGINT');
       fd = null;
 

--- a/lib/HappyThreadPool.js
+++ b/lib/HappyThreadPool.js
@@ -20,6 +20,13 @@ var HappyThread = require('./HappyThread');
  * @param {Boolean?} [config.debug=false]
  *        Allow this module and threads to log debugging information to the
  *        console.
+ *
+ * @param {Boolean?} [config.bufferedMessaging=false]
+ *        Compatibility mode for fork() on Windows where message exchange
+ *        between the master and worker processes is done serially.
+ *
+ *        This should be turned on if you're on Windows otherwise the process
+ *        could hang!
  */
 module.exports = function HappyThreadPool(config) {
   var rpcHandler = new HappyRPCHandler();
@@ -37,6 +44,7 @@ module.exports = function HappyThreadPool(config) {
     id: config.id,
     verbose: config.verbose,
     debug: config.debug,
+    buffered: config.bufferedMessaging,
   });
 
   var getThread = RoundRobinThreadPool(threads);

--- a/lib/HappyWorkerChannel.js
+++ b/lib/HappyWorkerChannel.js
@@ -3,25 +3,39 @@
 var JSONSerializer = require('./JSONSerializer');
 var HappyFakeCompiler = require('./HappyFakeCompiler');
 var HappyWorker = require('./HappyWorker');
+var BufferedFd = require('./BufferedFd')
+var UnbufferedFd = require('./UnbufferedFd')
 
 if (process.argv[1] === __filename) {
   startAsWorker();
 }
 
 function startAsWorker() {
-  HappyWorkerChannel(String(process.argv[2]), process);
+  HappyWorkerChannel(String(process.argv[2]), process, JSON.parse(process.argv[3] || '{}'));
 }
 
-function HappyWorkerChannel(id, stream) {
+function HappyWorkerChannel(id, fd, config) {
+  var BufferedFdImpl = config && config.buffered ? BufferedFd : UnbufferedFd;
+  var bfd = BufferedFdImpl.of(fd)
   var fakeCompilers = {};
   var workers = {};
+  var logSendError = function(err) {
+    if (err) {
+      console.warn('HappyWorker[%s]: unable to send to master!', id, err)
+    }
+  }
+
+  var send = function(message) {
+    BufferedFdImpl.send(bfd, message, logSendError)
+  }
+
   var handlers = {
     CONFIGURE: function(message) {
       findOrCreateFakeCompiler(message.data.compilerId)
         .configure(JSONSerializer.deserialize(message.data.compilerOptions))
       ;
 
-      stream.send({
+      send({
         id: message.id,
         name: 'CONFIGURE_DONE'
       });
@@ -30,7 +44,7 @@ function HappyWorkerChannel(id, stream) {
     COMPILE: function(message) {
       getWorker(message.data.loaderContext.compilerId)
         .compile(message.data, function(err, data) {
-          stream.send({
+          send({
             id: message.id,
             name: 'COMPILED',
             error: err,
@@ -47,8 +61,9 @@ function HappyWorkerChannel(id, stream) {
     },
   };
 
-  stream.on('message', accept);
-  stream.send({ name: 'READY' });
+  fd.on('message', accept)
+
+  send({ name: 'READY' });
 
   function accept(message) {
     var handler = handlers[message.name];
@@ -74,7 +89,7 @@ function HappyWorkerChannel(id, stream) {
       fakeCompilers[compilerId] = new HappyFakeCompiler({
         id: id,
         compilerId: compilerId,
-        send: stream.send.bind(stream)
+        send: send
       });
 
       workers[compilerId] = new HappyWorker({

--- a/lib/UnbufferedFd.js
+++ b/lib/UnbufferedFd.js
@@ -1,0 +1,12 @@
+var UnbufferedFd = exports
+
+UnbufferedFd.of = function(fd) {
+  return fd
+}
+
+UnbufferedFd.send = function(fd, message, callback) {
+  fd.send(message, undefined, undefined, callback)
+}
+
+UnbufferedFd.discard = function() {
+}

--- a/lib/UnbufferedFd.js
+++ b/lib/UnbufferedFd.js
@@ -1,11 +1,12 @@
 var UnbufferedFd = exports
+var processSend = require('./processSend')
 
 UnbufferedFd.of = function(fd) {
   return fd
 }
 
 UnbufferedFd.send = function(fd, message, callback) {
-  fd.send(message, undefined, undefined, callback)
+  processSend(fd, message, callback)
 }
 
 UnbufferedFd.discard = function() {

--- a/lib/__tests__/HappyPlugin.integration.test.js
+++ b/lib/__tests__/HappyPlugin.integration.test.js
@@ -10,7 +10,7 @@ var composeWebpackConfig = require('happypack-test-utils').composeWebpackConfig;
 describe('[Integration] HappyPlugin', function() {
   var testSuite = TestUtils.createIntegrationSuite(this);
 
-  it('compiles my files', function(done) {
+  function testCompilation(config, done) {
     var outputDir = testSuite.createDirectory('dist').path;
     var identityLoader = testSuite.createLoader(function(s) {
       return s;
@@ -57,11 +57,9 @@ describe('[Integration] HappyPlugin', function() {
         }]
       },
       plugins: [
-        new HappyPlugin({
-          verbose: true,
-          debug: true,
+        new HappyPlugin(Object.assign({}, config, {
           loaders: [loader.path, identityLoader.path]
-        })
+        }))
       ]
     });
 
@@ -78,6 +76,21 @@ describe('[Integration] HappyPlugin', function() {
 
       done();
     });
+  }
+
+  it('compiles my files', function(done) {
+    testCompilation({
+      verbose: true,
+      debug: true,
+    }, done)
+  });
+
+  it('compiles my files [buffered]', function(done) {
+    testCompilation({
+      bufferedMessaging: true,
+      verbose: true,
+      debug: true,
+    }, done)
   });
 
   it("resolves my loaders using webpack's loader resolver", function(done) {

--- a/lib/__tests__/HappyThreadPool.test.js
+++ b/lib/__tests__/HappyThreadPool.test.js
@@ -31,6 +31,30 @@ describe("HappyThreadPool", function() {
       });
     });
   });
+
+  describe('opening and closing threads in buffered mode', function() {
+    var subject;
+
+    afterEach(function stopCompiler(done) {
+      waitUntil(subject).itStops(done);
+      subject.stop('default');
+    });
+
+    it('works', function(done) {
+      subject = Subject({
+        size: 2,
+        bufferedMessaging: true,
+      });
+
+      var compiler = {};
+
+      subject.start('default', compiler, '{}', function(e) {
+        assert.ok(subject.isRunning());
+
+        done(e);
+      });
+    });
+  });
 });
 
 function waitUntil(subject) {

--- a/lib/__tests__/HappyWorkerChannel.test.js
+++ b/lib/__tests__/HappyWorkerChannel.test.js
@@ -3,7 +3,7 @@ var Channel = require('../HappyWorkerChannel');
 var HappyTestUtils = require('happypack-test-utils');
 var fixturePath = HappyTestUtils.fixturePath;
 
-describe('HappyWorkerChannel', function() {
+function testHappyWorkerChannel(config) {
   var loaders = [{ path: fixturePath('identity_loader.js') }];
   var fd, sourceCode, sourceMap;
 
@@ -18,7 +18,7 @@ describe('HappyWorkerChannel', function() {
       }
     });
 
-    Channel('c1', fd.remote);
+    Channel('c1', fd.remote, config);
 
     fd.local.send({
       name: 'CONFIGURE',
@@ -57,6 +57,14 @@ describe('HappyWorkerChannel', function() {
       }
     });
   });
+}
+
+describe('HappyWorkerChannel', function() {
+  testHappyWorkerChannel({})
+});
+
+describe('HappyWorkerChannel [buffered]', function() {
+  testHappyWorkerChannel({ buffered: true })
 });
 
 function FakeProcess() {
@@ -72,10 +80,14 @@ function FakeProcess() {
         remoteCallbacks.push(callback);
       },
 
-      send: function(payload) {
+      send: function(payload, x, y, callback) {
         messages.push(payload);
 
         localCallbacks.forEach(function(f) { f(payload); });
+
+        if (callback) {
+          callback()
+        }
       }
     },
 
@@ -84,8 +96,11 @@ function FakeProcess() {
         localCallbacks.push(callback);
       },
 
-      send: function(message) {
+      send: function(message, x, y, callback) {
         remoteCallbacks.forEach(function(f) { f(message); });
+        if (callback) {
+          callback()
+        }
       }
     }
   };

--- a/lib/processSend.js
+++ b/lib/processSend.js
@@ -1,0 +1,10 @@
+// node v4 accepted only 3 arguments while later versions accept 4, but the
+// callback is always the last
+module.exports = function processSend(fd, message, callback) {
+  if (fd.send.length === 3) {
+    return fd.send(message, undefined, callback)
+  }
+  else {
+    return fd.send(message, undefined, undefined, callback)
+  }
+}


### PR DESCRIPTION
refs GH-166

There seems to be a difference in how process.send() behaves with fork()
between platforms since on Windows if it's called a sufficiently large
number of times (on my box that's around 6k) the process simply hangs.
This does not seem to be the case on OS X or Linux.

The fix was to never invoke process.send() until its callback yields.