### PR TITLE
Add note that 4.0.1 is releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HappyPack Changelog
 
+### 4.0.1 
+- Released.
+
 ### 4.0.0-beta.5
 
 - Support for webpack{2,3} loader context API `this.getDependencies`


### PR DESCRIPTION
If you just look at the github repo you get the impression that the latest version of webpack is 3.0.3 and not 4.0.1 and that 4.x is in beta still. That is why I am proposing these changes.