### PR TITLE
Update resolver and loader syntax to work with webpack 4

### DIFF
--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -59,14 +59,13 @@ function addWebpack2Context(loader, context) {
 }
 
 function locatePluginList(loader) {
-  if (Array.isArray(loader.options.plugins)) {
+  if (Array.isArray(loader.options && loader.options.plugins)) {
     return loader.options.plugins;
   }
-  else if (typeof loader.options.plugins === 'function') {
+  else if (loader.options && typeof loader.options.plugins === 'function') {
     return loader.options.plugins();
   }
   else if (
-    !loader.options.plugins &&
     loader._compiler &&
     loader._compiler.options &&
     loader._compiler.options.plugins

--- a/lib/WebpackUtils.js
+++ b/lib/WebpackUtils.js
@@ -128,18 +128,22 @@ exports.resolveLoaders = function(compiler, loaders, done) {
   }), done);
 
   function resolveLoader(context, loader, callback) {
-    var resolve = compiler.resolvers.loader.resolve;
-    var resolveContext = compiler.resolvers.loader;
+    if (compiler.resolverFactory) {
+      compiler.resolverFactory.get("loader").resolve({}, context, loader, {}, callback);
+    } else {
+      var resolve = compiler.resolvers.loader.resolve;
+      var resolveContext = compiler.resolvers.loader;
 
-    // webpack2 has changed the signature for the resolve method where it accepts
-    // a fourth argument (context), so we need to sniff and support both versions
-    //
-    // fixes #23
-    if (resolve.length === 4) {
-      resolve.apply(resolveContext, [ context, context, loader, callback ])
-    }
-    else {
-      resolve.apply(resolveContext, [ context, loader, callback ]);
+      // webpack2 has changed the signature for the resolve method where it accepts
+      // a fourth argument (context), so we need to sniff and support both versions
+      //
+      // fixes #23
+      if (resolve.length === 4) {
+        resolve.apply(resolveContext, [ context, context, loader, callback ])
+      }
+      else {
+        resolve.apply(resolveContext, [ context, loader, callback ]);
+      }
     }
   }
 };


### PR DESCRIPTION
@amireh for some reason, I wasn't able to run the tests on the project.  At first I thought it was because I'm on Windows but I also tried on OSX and it also failed.  I tried these changes my work project using both webpack 3 and webpack 4 and it works for both.  Let me know if any additional fixes are needed.