### PR TITLE
Support raw of loaders

### DIFF
--- a/lib/applyLoaders.js
+++ b/lib/applyLoaders.js
@@ -1,5 +1,6 @@
 var HappyFakeLoaderContext = require('./HappyFakeLoaderContext');
 var fnOncePedantic = require('./fnOncePedantic');
+var convertArgs = require('./convertArgs');
 var assert = require('assert');
 
 /**
@@ -274,7 +275,11 @@ function NormalLoaderApplier(loaders, dataMap, done) {
       loader.module
     ;
 
-    applySyncOrAsync(fn, context, [ sourceCode, sourceMap ],
+    var raw = loader.module.raw;
+
+    var args = [ sourceCode, sourceMap ];
+
+    applySyncOrAsync(fn, context, convertArgs(args, raw),
       function(err, nextSource, nextSourceMap) {
         if (err) {
           return done(err);

--- a/lib/convertArgs.js
+++ b/lib/convertArgs.js
@@ -1,0 +1,24 @@
+module.exports = function convertArgs(args, raw) {
+  /* Not sure why buffer would convert to JSON */
+  if (args[0].type === 'Buffer') {
+    args[0] = Buffer.from(args[0].data);
+  }
+
+  if(!raw && Buffer.isBuffer(args[0])) {
+    args[0] = utf8BufferToString(args[0]);
+  }
+  else if(raw && typeof args[0] === "string") {
+    args[0] = new Buffer(args[0], "utf-8");
+  }
+
+  return args;
+}
+
+function utf8BufferToString(buf) {
+  var str = buf.toString("utf-8");
+  if(str.charCodeAt(0) === 0xFEFF) {
+    return str.substr(1);
+  } else {
+    return str;
+  }
+}


### PR DESCRIPTION
## Problems
The loaders of webpack supports `raw` options to decide the input should be `buffer` or `string`.

If loaders set `raw` to true as follow:
```js
export const raw = true;

// or
module.exports.raw = true;
```
Then, happypack should pass the content of file as buffer to them.

However, happypack currently only pass the content of file as string to each loader

## Solutions
Using [convertArgs](https://github.com/webpack/loader-runner/blob/0d41655430a52af88e6a423c6d8df5c22d413e81/lib/LoaderRunner.js#L148)  which official utils, [loader-runner](https://github.com/webpack/loader-runner), does to convert the content of file

Actually, there may be still some problems, for example, the format of `gif` may be broken after using happypack with image-webpack-loader, so the best solution is to introduce loader-runner to handle loaders

## Related Issues
#114, #204, #233, #240