### PR TITLE
【hard-source-webpack-plugin has 5 arguments】happypack can't support

### DIFF
--- a/lib/WebpackUtils.js
+++ b/lib/WebpackUtils.js
@@ -143,7 +143,7 @@ exports.resolveLoaders = function(compiler, loaders, done) {
       // a fourth argument (context), so we need to sniff and support both versions
       //
       // fixes #23
-      if (resolve.length === 4) {
+      if (resolve.length > 3) {
         resolve.apply(resolveContext, [ context, context, loader, callback ])
       }
       else {


### PR DESCRIPTION
throw signature changed error when running hard-source-webpack-plugin with happypack

here the issues:
https://github.com/mzgoddard/hard-source-webpack-plugin/issues/326
https://github.com/mzgoddard/hard-source-webpack-plugin/issues/439
